### PR TITLE
fix: catch unsupported css property and selector exception

### DIFF
--- a/src/domains/CSS.ts
+++ b/src/domains/CSS.ts
@@ -194,8 +194,12 @@ function formatMatchedCssRule(node: any, matchedCssRule: any) {
 
   const matchingSelectors: number[] = []
   each(selectors, (selector, idx) => {
-    if (stylesheet.matchesSelector(node, selector)) {
-      matchingSelectors.push(idx)
+    try {
+      if (stylesheet.matchesSelector(node, selector)) {
+        matchingSelectors.push(idx)
+      }
+    } catch (e) {
+      /* tslint:disable-next-line */
     }
   })
 

--- a/src/lib/stylesheet.ts
+++ b/src/lib/stylesheet.ts
@@ -76,7 +76,7 @@ export function formatStyle(style: any) {
   for (let i = 0, len = style.length; i < len; i++) {
     const name = style[i]
 
-    ret[name] = style[name]
+    ret[name] = style[name] || 'unsupported'
   }
 
   return ret


### PR DESCRIPTION
Nice work but little flaws when parse some css property and  selector exception like:

```css
* {
 --some-css-var: #ff0
}
```
be parsed as 


```css
* {
 --some-css-var: #ff0
}
```