### PR TITLE
fix: respect headers and method from request input parameter

### DIFF
--- a/src/lib/request.ts
+++ b/src/lib/request.ts
@@ -106,16 +106,17 @@ export class FetchRequest extends Emitter {
   private method: string
   private options: any
   private reqHeaders: any
-  constructor(url: any, options: any = {}) {
+  constructor(input: any, options: any = {}) {
     super()
 
-    if (url instanceof window.Request) url = url.url
+    const isRequest = input instanceof window.Request
+    const url = isRequest ? input.url : input
 
     this.url = fullUrl(url)
     this.id = createId()
     this.options = options
-    this.reqHeaders = options.headers || {}
-    this.method = options.method || 'GET'
+    this.reqHeaders = options.headers || (isRequest ? input.headers : {})
+    this.method = options.method || (isRequest ? input.method : 'GET')
   }
   send(fetchResult: any) {
     const options = this.options


### PR DESCRIPTION
`FetchRequest` is expected to be constucted with only single `Request` object as the first parameter of the constructor.

However, `FetchRequest` only extracts `url` from `Request` without `headers` and `method` for now.

This PR includes them as fallback value for `options`
 (the second parameter, `RequestInit` object) also so that can construct `FetchRequest` properly.