### PR TITLE
fix: stylesheet order sorted

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "devtools-protocol": "^0.0.1339468",
     "html2canvas": "^1.4.1",
     "licia": "^1.41.1",
-    "luna-dom-highlighter": "^1.0.2"
+    "luna-dom-highlighter": "^1.0.2",
+    "specificity": "^1.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.17.10",

--- a/src/domains/CSS.ts
+++ b/src/domains/CSS.ts
@@ -117,10 +117,14 @@ export function getMatchedStylesForNode(
   const node = getNode(params.nodeId)
   const matchedCSSRules = stylesheet.getMatchedCssRules(node)
 
+  const formatedMatchedCSSRules = map(matchedCSSRules, matchedCSSRule =>
+    formatMatchedCssRule(node, matchedCSSRule)
+  )
+  const sortedMatchedCSSRules = stylesheet.sortBySpecificity(
+    formatedMatchedCSSRules
+  )
   return {
-    matchedCSSRules: map(matchedCSSRules, matchedCSSRule =>
-      formatMatchedCssRule(node, matchedCSSRule)
-    ),
+    matchedCSSRules: sortedMatchedCSSRules,
     ...getInlineStylesForNode(params),
   }
 }

--- a/src/lib/stylesheet.ts
+++ b/src/lib/stylesheet.ts
@@ -3,6 +3,11 @@ import Emitter from 'licia/Emitter'
 import strHash from 'licia/strHash'
 import toStr from 'licia/toStr'
 import trim from 'licia/trim'
+import {
+  compare as specCompare,
+  compareDesc as specCompareDesc,
+  calculate as specCalculate,
+} from 'specificity'
 import { createId, getTextContent } from './util'
 
 const elProto: any = Element.prototype
@@ -133,4 +138,28 @@ function getStyleSheetId(sourceUrl = '') {
   }
 
   return createId()
+}
+
+function getSelectorsByCssRule(cssRule: any) {
+  return cssRule.matchingSelectors.map((selectorId: string) => {
+    const selector = cssRule.rule.selectorList.selectors[selectorId]
+    return selector.text
+  })
+}
+function selectMaxSpecificity(selectors: string[]) {
+  if (selectors.length < 1) return '*'
+  if (selectors.length === 1) return selectors[0]
+  else {
+    return selectors.sort((s1, s2) => {
+      return specCompareDesc(specCalculate(s1), specCalculate(s2))
+    })[0]
+  }
+}
+
+export function sortBySpecificity(matchedCssRules: any[]) {
+  return matchedCssRules.sort((cssRule1, cssRule2) => {
+    const selector1 = selectMaxSpecificity(getSelectorsByCssRule(cssRule1))
+    const selector2 = selectMaxSpecificity(getSelectorsByCssRule(cssRule2))
+    return specCompare(specCalculate(selector1), specCalculate(selector2))
+  })
 }


### PR DESCRIPTION
修复`CSS.getMatchedStylesForNode` 返回的 `matchedCSSRules` 未按selector权重排序的问题。
Fixes #16 